### PR TITLE
add /koda channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [/zora](https://warpcast.com/~/channel/zora)
 - [/bright-moments](https://warpcast.com/~/channel/bright-moments)
 - [/fxhash](https://warpcast.com/~/channel/fxhash)
+- [/koda](https://warpcast.com/~/channel/koda)
 - [/gallery](https://warpcast.com/~/channel/gallery)
 - [/artblocks](https://warpcast.com/~/channel/artblocks)
 - [/highlight](https://warpcast.com/~/channel/highlight)


### PR DESCRIPTION
Add [Farcaster /koda channel](https://warpcast.com/~/channel/koda)

We started our presence with artists two weeks ago and recently hit 70 subscribers. 
Originally, we were based at [Twitter @kodadot](https://twitter.com/kodadot)

The rule is 100 for project channel

https://warpcast.com/kugusha.eth/0x562f0b76

![image](https://github.com/kugusha/art-farcaster/assets/5887929/d2b129fd-a654-461e-9596-5caf18cb9a3d)
